### PR TITLE
Fixing a crash in case of an undefined component array

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-test-renderer",
-  "version": "0.0.5",
+  "version": "0.0.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-test-renderer",
-  "version": "0.0.9",
+  "version": "0.0.10",
   "license": "MIT",
   "description": "Allows developers to render RNN screens without depending on the native hierarchy maintained by RNN.",
   "author": {

--- a/src/NavigationMock.tsx
+++ b/src/NavigationMock.tsx
@@ -169,7 +169,7 @@ class NativeNavigationMock {
 
   private callComponentDidDisappear(componentId: string | number) {
     const componentArr = this.callbacksByComponentId.get(componentId);
-    componentArr.forEach((component) => {
+    componentArr?.forEach((component) => {
       component?.componentDidDisappear?.();
     })
   }


### PR DESCRIPTION
Using the components array in callComponentDidDisappear as optional since they might yield undefined.