### PR TITLE
Remove warnings while running tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-test-renderer",
-  "version": "0.0.10",
+  "version": "0.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-navigation-test-renderer",
-  "version": "0.0.14",
+  "version": "0.0.15",
   "license": "MIT",
   "description": "Allows developers to render RNN screens without depending on the native hierarchy maintained by RNN.",
   "author": {

--- a/src/NavigationMock.tsx
+++ b/src/NavigationMock.tsx
@@ -282,7 +282,7 @@ export function withNativeNavigation<T extends InjectedNavigationProps>(
           if (btn) btnsAndTitleArray.push(btn)
         })
         const  title = options?.topBar?.title?.text;
-        if (title) btnsAndTitleArray.push(<Text>{title}</Text>);
+        if (title) btnsAndTitleArray.push(<Text key={title}>{title}</Text>);
         return btnsAndTitleArray
       }
 


### PR DESCRIPTION
I'm getting console warnings in my tests when using `react-native-navigation-test-renderer` due to missing unique key. This PR fixes the issue.